### PR TITLE
Add option to use hex key

### DIFF
--- a/skip32.js
+++ b/skip32.js
@@ -15,14 +15,26 @@
 
    Not copyright, no rights reserved.
 */
-function Skip32(key) {
-    if (typeof key === 'string') {
-      this.key = this.keyFromHex(key);
-    } else {
-      this.key = new Uint8Array(10);
-      for (var i = 0; i < 10; i++) this.key[i] = key[i % key.length];
+function Skip32(key, lpadZero) {
+    // If key seems to be a valid hex string parse it into an array of bytes
+    if (typeof key === 'string' && key.match(/^([0-9A-Fa-f]{2})+$/)) {
+      key = key.split(/(..)/).filter(s => s).map(s => parseInt(s, 16))
     }
-};
+
+    // if lpadZero parameter given and truthy left pad array with 0 as needed
+    if (typeof lpadZero !== 'undefined' && lpadZero) {
+      console.log("left padding %j", key)
+      while (key.length < 10) key.unshift(0);
+      console.log("left padded  %j", key)
+    }
+
+    this.key = new Uint8Array(10);
+    for (var i = 0; i < 10; i++) this.key[i] = key[i % key.length];
+}
+
+// NOTE: we expose a KEYLEN constant in case anything needs to code against it,
+// but we don't reference it in this module for performance reasons
+Object.defineProperty(Skip32, 'KEYLEN', { value: 10 })
 
 Skip32.prototype.init = function(){
 };
@@ -69,19 +81,6 @@ Skip32.prototype.core = function(n,k,d){
 		k+=d;
 	}
 	return ((wr << 16) | wl)>>>0;
-}
-
-Skip32.prototype.keyFromHex = function(hex) {
-  var i, b=[];
-  for (i=0; i<hex.length-1;i+=2){
-    b.push(parseInt(hex.substr(i,2),16));
-  }
-
-  while (b.length < 10) {
-    b.unshift(0);
-  }
-
-  return b;
 }
 
 Skip32.prototype.encrypt = function(n){

--- a/skip32.js
+++ b/skip32.js
@@ -16,8 +16,12 @@
    Not copyright, no rights reserved.
 */
 function Skip32(key) {
-    this.key = new Uint8Array(10);
-    for (var i = 0; i < 10; i++) this.key[i] = key[i % key.length];
+    if (typeof key === 'string') {
+      this.key = this.keyFromHex(key);
+    } else {
+      this.key = new Uint8Array(10);
+      for (var i = 0; i < 10; i++) this.key[i] = key[i % key.length];
+    }
 };
 
 Skip32.prototype.init = function(){
@@ -65,6 +69,19 @@ Skip32.prototype.core = function(n,k,d){
 		k+=d;
 	}
 	return ((wr << 16) | wl)>>>0;
+}
+
+Skip32.prototype.keyFromHex = function(hex) {
+  var i, b=[];
+  for (i=0; i<hex.length-1;i+=2){
+    b.push(parseInt(hex.substr(i,2),16));
+  }
+
+  while (b.length < 10) {
+    b.unshift(0);
+  }
+
+  return b;
 }
 
 Skip32.prototype.encrypt = function(n){

--- a/test.js
+++ b/test.js
@@ -16,13 +16,23 @@ console.log("expected:", INPUT.toString(16), "->", ENCRYPTED.toString(16), "->",
 console.log("     got:", INPUT.toString(16), "->", e.toString(16), "->", d.toString(16));
 console.log();
 
-// verify that key extension logic works as expected (bytes of short keys should repeat, not get padded with zeros) 
+// verify that key extension logic works as expected (bytes of short keys should repeat, not get padded with zeros unless lpadZero param given) 
 var SHORT_KEY = [ 0xDE, 0xAD, 0xBE, 0xEF ], short = new Skip32(SHORT_KEY);
 var REPEATED_SHORT_KEY = [ 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD ], repeated_short = new Skip32(REPEATED_SHORT_KEY);
-var PADDED_SHORT_KEY = [ 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ], padded_short = new Skip32(PADDED_SHORT_KEY);
+var RIGHT_PADDED_SHORT_KEY = [ 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ], right_padded_short = new Skip32(RIGHT_PADDED_SHORT_KEY);
+var LEFT_PADDED_SHORT_KEY = [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF ], left_padded_short = new Skip32(LEFT_PADDED_SHORT_KEY);
+
+// verify that the short test key is less than the expected length
+assert(SHORT_KEY.length < Skip32.KEYLEN);
 
 assert.equal(short.encrypt(INPUT), repeated_short.encrypt(INPUT));
-assert.notEqual(short.encrypt(INPUT), padded_short.encrypt(INPUT));
+assert.notEqual(short.encrypt(INPUT), right_padded_short.encrypt(INPUT));
+assert.notEqual(short.encrypt(INPUT), left_padded_short.encrypt(INPUT));
+// verify optional left padding works as expected
+assert.equal((new Skip32(SHORT_KEY, true)).encrypt(INPUT), left_padded_short.encrypt(INPUT));
+// verify hex parsing
+var SHORT_KEY_HEX = "DEADBEEF";
+assert.equal((new Skip32(SHORT_KEY_HEX)).encrypt(INPUT), short.encrypt(INPUT));
 
 // some speed tests follow
 


### PR DESCRIPTION
@manico Take a look at let me know if this meets your needs.  The only functional difference from your implementation is that if you want the "left pad with 0" behavior you have to pass true as a second parameter to the constructor, e.g.

`var s = new Skip32("DEADBEEF", true);`

without that parameter you can still pass a hex string but if it yields less than 10 bytes they'll be repeated, i.e.

`new Skip32("DEADBEEF")`

is equivalent to

`new Skip32("DEADBEEFDEADBEEFDEAD")`
